### PR TITLE
Return resolve, otherwise will give error 'download(...).then() is no…

### DIFF
--- a/src/GoogleWebfonts.js
+++ b/src/GoogleWebfonts.js
@@ -102,7 +102,9 @@ class Selection {
 		}
 		const cacheFilePath = tmpFile('google-fonts-webpack-' + md5(url))
 		if (fs.existsSync(cacheFilePath)) {
-			return fs.readFileSync(cacheFilePath)
+			return new Promise((resolve, reject) => {
+				resolve(fs.readFileSync(cacheFilePath))
+			})
 		} else {
 			return fetch(url)
 				.then(response => {


### PR DESCRIPTION
Apologies, there was a grave error in my previous patch causing the build process to fail. This PR resolves it