### PR TITLE
Better cache code & make tests pass

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,8 +18,8 @@
     "plugin"
   ],
   "scripts": {
-    "test": "mocha spec --colors",
-    "watch": "mocha spec --colors --watch"
+    "test": "mocha --timeout 5000 spec --colors",
+    "watch": "mocha --timeout 5000 spec --colors --watch"
   },
   "devDependencies": {
     "eslint": "^5.0.1",

--- a/spec/GoogleWebfontsPlugin.js
+++ b/spec/GoogleWebfontsPlugin.js
@@ -1,6 +1,8 @@
 const should = require("should");
 const webpack = require("webpack");
 const MemoryFs = require("memory-fs");
+const nodeFS = require("fs");
+const os = require("os");
 const GoogleWebfontPlugin = require("../src");
 
 const webpackConfig = {
@@ -64,4 +66,10 @@ describe("GoogleWebfontPlugin", () => {
 		fs.existsSync("/styles/fonts.css").should.be.ok();
 		fs.readFileSync("/styles/fonts.css", "utf8").should.containEql("./font/Roboto-Regular.woff")
 	});
+
+	it("downloaded files are cached", () => {
+		nodeFS.readdirSync(os.tmpdir()).filter(fn => {
+			return fn.endsWith(".zip") && fn.startsWith("google-fonts-webpack")
+		}).should.not.be.exactly(0)
+	})
 });


### PR DESCRIPTION
* Separate caching from download() function to not break tests dependent on it
* Add test to check if downloaded files are cached
* Add a timeout to `mocha` to wait for the zip file to download which then resolves promise