### PR TITLE
google-webfonts-helper doesnt provide local names anymore

### DIFF
--- a/src/GoogleWebfonts.js
+++ b/src/GoogleWebfonts.js
@@ -28,7 +28,7 @@ function tmpFile(filename) {
 }
 
 function getVariantCss({ variant, info, font, formats, display, fontsPath }) {
-	const src = Object.prototype.hasOwnProperty.call(info, 'local') ? info.local.map(fileName => `local("${fileName}")`) : ["local("+info.fontFamily+")"]
+	const src = ["local("+info.fontFamily+")"]
 	let fallback
 	formats.forEach(ext => {
 		if(ext in info) {


### PR DESCRIPTION
Since today with this plugin im getting the following error:
![image](https://user-images.githubusercontent.com/6339036/99388942-9dc55600-28d6-11eb-82db-a4a83cbeba49.png)

Researched the Problem and as it seems - google-webfonts-helper/google fonts doesnt provide local names anymore:

![image](https://user-images.githubusercontent.com/6339036/99389089-d107e500-28d6-11eb-9557-8bb2ce9ed1e5.png)
