### PR TITLE
[rfc]: added proxy support via proxy-agent

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,30 @@ module.exports = {
 }
 ```
 
+### with Proxy
+
+`/webpack.config.js`
+```js
+const GoogleFontsPlugin = require("@beyonk/google-fonts-webpack-plugin")
+
+module.exports = {
+	"entry": "index.js",
+	/* ... */
+	plugins: [
+		new GoogleFontsPlugin({
+			proxy: {
+				protocol: "http:",
+				port: "1024",
+				hostname: "proxy.corporate.com",
+				ciphers: 'TLS_AES_256_GCM_SHA384:ECDHE-RSA-AES256-GCM-SHA384',
+				minVersion: "TLSv1.2",
+            }
+			/* ...options */
+		})
+	]
+}
+```
+
 ## Options
 
 ```js
@@ -51,7 +75,7 @@ new GoogleFontsPlugin(options: Object)
 |noLocalInCss|`Boolean`|`false`|Whether to prepend `local(FontName)` expression before font files in CSS file ([see MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/@font-face/src)).
 |formats|`Array`|`[ "eot", "woff", "woff2", "ttf", "svg" ]`|Font formats to download.
 |apiUrl|`String`|`"https://google-webfonts-helper.herokuapp.com/api/fonts"`|google-webfonts-helper API url.
-
+|proxy|`ProxyAgentOptionObject`|`undefined`|settings which get passed to the ProxyAgent ([see Repo](https://github.com/TooTallNate/node-proxy-agent)). Setting this to `undefined` (default) leads to a disable ProxyAgent and setting it to `{}` let the plugin read the environment variables `HTTP_PROXY`, `HTTPS_PROXY` and `NO_PROXY`. It's also possible to define the proxy settings via webpack config 
 
 ### FontObject
 

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "md5": "^2.2.1",
     "node-fetch": "^2.1.2",
     "webpack-sources": "^1.1.0",
+    "proxy-agent": "^4.0.1",
     "yauzl": "^2.8.0"
   },
   "peerDependencies": {

--- a/src/GoogleWebfonts.js
+++ b/src/GoogleWebfonts.js
@@ -27,17 +27,20 @@ const FONT_FACE = ({ fontFamily, fontStyle, fontWeight, display, src, fallback }
 `
 
 function configureProxy(options) {
-	// default proxy is undefined, no proxy will be used (proxy: false)
-	proxy = undefined
-	const type = typeof options
-
-	if (type === 'object') {
-		// use webpack config if available
-		proxy = new ProxyAgent(options)
-	} else if(type === "boolean" && options !== false) {
-		// if enabled `proxy: true` use proxy agent using config from environment vars
+	// ProxyAgent instance with environment variable config
+	if(!_.isUndefined(options) && _.isEmpty(options)) {
 		proxy = new ProxyAgent()
+		return;
 	}
+
+	// ProxyAgent instance with custom options
+	if (_.isObject(options)) {
+		proxy = new ProxyAgent(options)
+		return;
+	}
+
+	// default proxy is undefined, no proxy will be used
+	proxy = undefined
 }
 
 function getFetchOptions() {

--- a/src/index.js
+++ b/src/index.js
@@ -16,7 +16,7 @@ const defaults = {
     path: "font",
     local: true,
     noLocalInCss: false,
-    proxy: false
+    proxy: undefined
 }
 
 const pluginSignature = {

--- a/src/index.js
+++ b/src/index.js
@@ -15,7 +15,8 @@ const defaults = {
     filename: "fonts.css",
     path: "font",
     local: true,
-    noLocalInCss: false
+    noLocalInCss: false,
+    proxy: false
 }
 
 const pluginSignature = {
@@ -28,6 +29,8 @@ class GoogleWebfontsPlugin {
         this.chunk = new Chunk(this.options.name)
         this.chunk.ids = []
         this.chunk.name = this.options.name
+
+        GoogleWebfonts.configureProxy(this.options.proxy)
     }
 
     get api () {


### PR DESCRIPTION
sadly node has not added proxy support to its core yet (https://github.com/nodejs/node/issues/15620)  so it is necessary to implement it in each client lib -.-

i added proxy support to via https://github.com/TooTallNate/node-proxy-agent to your awesome lib.

i haven't added tests yes and i am not sure about correctly updating the `package-lock.json` (had not worked on a node module before). is it just a `npm install` required to generate the correct lock file or is there something special for a node module?

also i am not quite happy with the mixed type variable (boolean/object), i thought about `empty object`, `object` and `undefined`

references:
- https://github.com/node-fetch/node-fetch/issues/1016

edit: not really an idea how to test this.

edit2: as proxyagent should work transparent, maybe using it could be the default